### PR TITLE
add raw data to unsuccessful response

### DIFF
--- a/Restivus/Http.swift
+++ b/Restivus/Http.swift
@@ -17,7 +17,7 @@ public enum HTTPError: Error {
     unexpectedResponse(URLResponse),
 
     ///The HTTPURLResponse has a status code other than 2xx
-    unsuccessfulResponse(HTTPURLResponse),
+    unsuccessfulResponse(HTTPURLResponse, Data?),
 
     /// The returned data cannot be deserialized into the expected type
     unableToDeserializeJSON(error: Error, data: Data?),
@@ -46,8 +46,8 @@ extension HTTPError: Equatable {
         case (let .unexpectedResponse(response1), let .unexpectedResponse(response2)):
             return response1.isEqual(response2)
             
-        case (let .unsuccessfulResponse(response1), let .unsuccessfulResponse(response2)):
-            return response1.statusCode == response2.statusCode
+        case (let .unsuccessfulResponse(response1, data1), let .unsuccessfulResponse(response2, data2)):
+            return response1.statusCode == response2.statusCode && data1 == data2
             
         case(.unableToDeserializeJSON, .unableToDeserializeJSON):
             return true // nearly impossible to equate these 2 things accurately

--- a/Restivus/Http.swift
+++ b/Restivus/Http.swift
@@ -14,7 +14,7 @@ public enum HTTPError: Error {
     case noResponse,
 
     /// The URLResponse is not of the expected type
-    unexpectedResponse(URLResponse),
+    unexpectedResponse(URLResponse, Data?),
 
     ///The HTTPURLResponse has a status code other than 2xx
     unsuccessfulResponse(HTTPURLResponse, Data?),
@@ -23,7 +23,7 @@ public enum HTTPError: Error {
     unableToDeserializeJSON(error: Error, data: Data?),
 
     /// Some other non-HttpError is raised.
-    other(Error)
+    other(Error, Data?)
 }
 
 /// Determines if 2 HttpErrors are _roughly_ equal.
@@ -43,8 +43,8 @@ extension HTTPError: Equatable {
         switch (lhs, rhs) {
         case (.noResponse, .noResponse): return true
             
-        case (let .unexpectedResponse(response1), let .unexpectedResponse(response2)):
-            return response1.isEqual(response2)
+        case (let .unexpectedResponse(response1, data1), let .unexpectedResponse(response2, data2)):
+            return response1.isEqual(response2) && data1 == data2
             
         case (let .unsuccessfulResponse(response1, data1), let .unsuccessfulResponse(response2, data2)):
             return response1.statusCode == response2.statusCode && data1 == data2
@@ -52,8 +52,8 @@ extension HTTPError: Equatable {
         case(.unableToDeserializeJSON, .unableToDeserializeJSON):
             return true // nearly impossible to equate these 2 things accurately
             
-        case (.other, .other):
-            return true // cannot accurately compare the underlying Error types as Error is a protocol
+        case (let .other(_, data1), let .other(_, data2)):
+            return data1 == data2 // cannot accurately compare the underlying Error types as Error is a protocol
             
         default: return false
         }

--- a/Restivus/Restable.swift
+++ b/Restivus/Restable.swift
@@ -261,7 +261,7 @@ extension Restable {
                                                              userInfo: ["response": httpResponse]))
             }
             
-            completion?(Result.failure(HTTPError.unsuccessfulResponse(httpResponse)))
+            completion?(Result.failure(HTTPError.unsuccessfulResponse(httpResponse, data)))
             return
         }
         

--- a/Restivus/Restable.swift
+++ b/Restivus/Restable.swift
@@ -241,7 +241,7 @@ extension Restable {
     func dataTaskCompletionHandler(data: Data?, response: URLResponse?, error: Error?,
                                    completion: RestableCompletionHandler<ResponseType>?) {
         guard error == nil else {
-            completion?(Result.failure(.other(error!)))
+            completion?(Result.failure(.other(error!, data)))
             return
         }
         
@@ -251,7 +251,7 @@ extension Restable {
         }
         
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion?(Result.failure(.unexpectedResponse(response)))
+            completion?(Result.failure(.unexpectedResponse(response, data)))
             return
         }
         

--- a/RestivusTests/HttpErrorSpec.swift
+++ b/RestivusTests/HttpErrorSpec.swift
@@ -30,8 +30,10 @@ class HttpErrorSpec: QuickSpec {
                     let url = URL(string: "http://google.ca")
                     let response1 = HTTPURLResponse(url: url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
                     let response2 = HTTPURLResponse(url: url!, statusCode: 204, httpVersion: nil, headerFields: nil)!
-                    expect(HTTPError.unsuccessfulResponse(response1)).toNot(equal(HTTPError.unsuccessfulResponse(response2)))
-                    expect(HTTPError.unsuccessfulResponse(response1)).to(equal(HTTPError.unsuccessfulResponse(response1)))
+                    let data1 = "{\"message\": \"data1\"}".data(using: .utf8)
+                    let data2 = "{\"message\": \"data2\"}".data(using: .utf8)
+                    expect(HTTPError.unsuccessfulResponse(response1, data1)).toNot(equal(HTTPError.unsuccessfulResponse(response2, data2)))
+                    expect(HTTPError.unsuccessfulResponse(response1, data1)).to(equal(HTTPError.unsuccessfulResponse(response1, data1)))
                 }
                 
                 it("does not consider internals when comparing unableTodeserializeJSON") {

--- a/RestivusTests/HttpErrorSpec.swift
+++ b/RestivusTests/HttpErrorSpec.swift
@@ -15,15 +15,17 @@ class HttpErrorSpec: QuickSpec {
         describe("An HttpError") {
             describe("its equality") {
                 it("is not equal if not the same errors") {
-                    expect(HTTPError.other(HTTPError.noResponse)).toNot(equal(HTTPError.noResponse))
+                    expect(HTTPError.other(HTTPError.noResponse, Data())).toNot(equal(HTTPError.noResponse))
                     expect(HTTPError.noResponse) == HTTPError.noResponse
                 }
                 
                 it("considers URLResponse when comparing unexpectedResponse") {
                     let response1 = URLResponse()
                     let response2 = URLResponse()
-                    expect(HTTPError.unexpectedResponse(response1)).toNot(equal(HTTPError.unexpectedResponse(response2)))
-                    expect(HTTPError.unexpectedResponse(response1)).to(equal(HTTPError.unexpectedResponse(response1)))
+                    let data1 = "{\"message\": \"data1\"}".data(using: .utf8)
+                    let data2 = "{\"message\": \"data2\"}".data(using: .utf8)
+                    expect(HTTPError.unexpectedResponse(response1, data1)).toNot(equal(HTTPError.unexpectedResponse(response2, data2)))
+                    expect(HTTPError.unexpectedResponse(response1, data1)).to(equal(HTTPError.unexpectedResponse(response1, data1)))
                 }
                 
                 it("considers HTTPURLResponses when comparing unsuccessfulResponses") {
@@ -37,14 +39,15 @@ class HttpErrorSpec: QuickSpec {
                 }
                 
                 it("does not consider internals when comparing unableTodeserializeJSON") {
-                    let unable1 = HTTPError.unableToDeserializeJSON(error: HTTPError.other(HTTPError.noResponse), data: nil)
+                    let unable1 = HTTPError.unableToDeserializeJSON(error: HTTPError.other(HTTPError.noResponse, nil), data: nil)
                     let unable2 = HTTPError.unableToDeserializeJSON(error: HTTPError.noResponse, data: Data())
                     expect(unable1) == unable2
                 }
                 
-                it("does not consider internals when comparing others") {
-                    let other1 = HTTPError.other(HTTPError.other(HTTPError.noResponse))
-                    let other2 = HTTPError.other(HTTPError.noResponse)
+                it("does not consider internal errors when comparing others") {
+                    let data = Data()
+                    let other1 = HTTPError.other(HTTPError.other(HTTPError.noResponse, nil), data)
+                    let other2 = HTTPError.other(HTTPError.noResponse, data)
                     expect(other1) == other2
                 }
             }

--- a/RestivusTests/RestableConfiguration.swift
+++ b/RestivusTests/RestableConfiguration.swift
@@ -60,11 +60,12 @@ class RestableConfiguration: QuickConfiguration {
                     var error: HTTPError?
                     let response = HTTPURLResponse(url: URL(string: "google.ca")!, statusCode: 403, httpVersion: nil,
                                                    headerFields: nil)!
-                    restable.dataTaskCompletionHandler(data: Data(), response: response, error: nil) {
+                    let data = Data()
+                    restable.dataTaskCompletionHandler(data: data, response: response, error: nil) {
                         if case let Result.failure(err) = $0 { error = err }
                     }
-                    
-                    expect(error).toEventually(equal(HTTPError.unsuccessfulResponse(response)))
+
+                    expect(error).toEventually(equal(HTTPError.unsuccessfulResponse(response, data)))
                 }
             }
             

--- a/RestivusTests/RestableConfiguration.swift
+++ b/RestivusTests/RestableConfiguration.swift
@@ -30,11 +30,12 @@ class RestableConfiguration: QuickConfiguration {
             context("it fails") {
                 it("completes with an HTTPError.other if an error occured.") {
                     var error: HTTPError?
-                    restable.dataTaskCompletionHandler(data: nil, response: HTTPURLResponse(),
+                    let data = Data()
+                    restable.dataTaskCompletionHandler(data: data, response: HTTPURLResponse(),
                                                        error: HTTPError.noResponse) {
                         if case let Result.failure(err) = $0 { error = err }
                     }
-                    expect(error).toEventually(equal(HTTPError.other(HTTPError.noResponse)))
+                    expect(error).toEventually(equal(HTTPError.other(HTTPError.noResponse, data)))
                 }
                 
                 it("completes with HTTPError.noResponse when the server does not respond.") {
@@ -49,11 +50,12 @@ class RestableConfiguration: QuickConfiguration {
                 it("completes with HTTPError.unexpectedResponse when the URLResponse is not an HTTPURLResponse") {
                     var error: HTTPError?
                     let response = URLResponse()
-                    restable.dataTaskCompletionHandler(data: Data(), response: response, error: nil) {
+                    let data = Data()
+                    restable.dataTaskCompletionHandler(data: data, response: response, error: nil) {
                         if case let Result.failure(err) = $0 { error = err }
                     }
                     
-                    expect(error).toEventually(equal(HTTPError.unexpectedResponse(response)))
+                    expect(error).toEventually(equal(HTTPError.unexpectedResponse(response, data)))
                 }
                 
                 it("completes with HTTPError.unsuccessfulResponse when the response code is not a 2xx") {


### PR DESCRIPTION
This is an attempt to address #6. I've added `Data` to `unsuccessfulResponse(HTTPURLResponse)`. 