### PR TITLE
#8 - well, that was embarassing.

### DIFF
--- a/Restivus.xcodeproj/project.pbxproj
+++ b/Restivus.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		7DDB69561F4B6FA1001CC66D /* Restivous.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DDB69481F4B6FA1001CC66D /* Restivous.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7DDB69671F4B705D001CC66D /* Restable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DDB69631F4B705D001CC66D /* Restable.swift */; };
 		7DDB69751F4BE06B001CC66D /* HTTPURLResponse+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DDB69741F4BE06B001CC66D /* HTTPURLResponse+Extensions.swift */; };
+		C22D22D22090B0E500E78B03 /* ResultFormatSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22D22D12090B0E500E78B03 /* ResultFormatSpec.swift */; };
+		C22D22D32090B0E500E78B03 /* ResultFormatSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22D22D12090B0E500E78B03 /* ResultFormatSpec.swift */; };
+		C22D22D42090B0E500E78B03 /* ResultFormatSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22D22D12090B0E500E78B03 /* ResultFormatSpec.swift */; };
 		C26230211F4C8A08003A5E99 /* URLRequest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C26230201F4C8A08003A5E99 /* URLRequest+Extensions.swift */; };
 		C28474171FFBFFF900E13F56 /* Http.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28474101FFBFFF900E13F56 /* Http.swift */; };
 		C28474181FFBFFF900E13F56 /* ResultEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28474111FFBFFF900E13F56 /* ResultEncoding.swift */; };
@@ -206,6 +209,7 @@
 		7DDB69551F4B6FA1001CC66D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7DDB69631F4B705D001CC66D /* Restable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Restable.swift; sourceTree = "<group>"; };
 		7DDB69741F4BE06B001CC66D /* HTTPURLResponse+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HTTPURLResponse+Extensions.swift"; sourceTree = "<group>"; };
+		C22D22D12090B0E500E78B03 /* ResultFormatSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultFormatSpec.swift; sourceTree = "<group>"; };
 		C2380A831F50B753004C1B04 /* DeletableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletableSpec.swift; sourceTree = "<group>"; };
 		C23F9A801F584395000CE9E6 /* RawDecodableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDecodableSpec.swift; sourceTree = "<group>"; };
 		C2548E0D1F545366003EDE96 /* GettableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GettableSpec.swift; sourceTree = "<group>"; };
@@ -317,6 +321,7 @@
 				C2548E111F54550F003EDE96 /* PostableSpec.swift */,
 				C2548E131F54553E003EDE96 /* PuttableSpec.swift */,
 				C2C7F4B01FF41530003578A8 /* PreEncodedRestablesSpec.swift */,
+				C22D22D12090B0E500E78B03 /* ResultFormatSpec.swift */,
 			);
 			name = http;
 			sourceTree = "<group>";
@@ -792,6 +797,7 @@
 				C28474A71FFC05DA00E13F56 /* PreEncodedRestablesSpec.swift in Sources */,
 				C284747C1FFC05BC00E13F56 /* HTTPURLResponse+ExtensionsSpec.swift in Sources */,
 				C28474871FFC05C600E13F56 /* HTTPMethodConfiguration.swift in Sources */,
+				C22D22D32090B0E500E78B03 /* ResultFormatSpec.swift in Sources */,
 				C28474A61FFC05DA00E13F56 /* PuttableSpec.swift in Sources */,
 				C28474891FFC05C600E13F56 /* PreEncodedRestableConfiguration.swift in Sources */,
 				C284748E1FFC05CC00E13F56 /* Person.swift in Sources */,
@@ -818,6 +824,7 @@
 				C28474E61FFC11B800E13F56 /* PuttableSpec.swift in Sources */,
 				C28474EB1FFC11B800E13F56 /* NotificationCenterPublishableSpec.swift in Sources */,
 				C28474EA1FFC11B800E13F56 /* InterceptableSpec.swift in Sources */,
+				C22D22D22090B0E500E78B03 /* ResultFormatSpec.swift in Sources */,
 				C28474DE1FFC11B800E13F56 /* Person.swift in Sources */,
 				C28474DC1FFC11B800E13F56 /* RestableConfiguration.swift in Sources */,
 				C28474E11FFC11B800E13F56 /* HTTPMethodSpec.swift in Sources */,
@@ -844,6 +851,7 @@
 				C28474F91FFC11B900E13F56 /* PuttableSpec.swift in Sources */,
 				C28474FE1FFC11B900E13F56 /* NotificationCenterPublishableSpec.swift in Sources */,
 				C28474FD1FFC11B900E13F56 /* InterceptableSpec.swift in Sources */,
+				C22D22D42090B0E500E78B03 /* ResultFormatSpec.swift in Sources */,
 				C28474F11FFC11B900E13F56 /* Person.swift in Sources */,
 				C28474EF1FFC11B900E13F56 /* RestableConfiguration.swift in Sources */,
 				C28474F41FFC11B900E13F56 /* HTTPMethodSpec.swift in Sources */,

--- a/Restivus.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Restivus.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Restivus.xcodeproj/xcshareddata/xcschemes/Restivus-iOS.xcscheme
+++ b/Restivus.xcodeproj/xcshareddata/xcschemes/Restivus-iOS.xcscheme
@@ -40,10 +40,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C28474BE1FFC0BEF00E13F56"
+               BuildableName = "Restivus-iOSTests.xctest"
+               BlueprintName = "Restivus-iOSTests"
+               ReferencedContainer = "container:Restivus.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -61,7 +70,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Restivus.xcodeproj/xcshareddata/xcschemes/Restivus-iOSTests.xcscheme
+++ b/Restivus.xcodeproj/xcshareddata/xcschemes/Restivus-iOSTests.xcscheme
@@ -10,7 +10,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -31,7 +30,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Restivus.xcodeproj/xcshareddata/xcschemes/Restivus-macOS.xcscheme
+++ b/Restivus.xcodeproj/xcshareddata/xcschemes/Restivus-macOS.xcscheme
@@ -40,9 +40,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C28474631FFC05B100E13F56"
+               BuildableName = "Restivus-macOSTests.xctest"
+               BlueprintName = "Restivus-macOSTests"
+               ReferencedContainer = "container:Restivus.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -60,7 +70,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Restivus.xcodeproj/xcshareddata/xcschemes/Restivus-tvOS.xcscheme
+++ b/Restivus.xcodeproj/xcshareddata/xcschemes/Restivus-tvOS.xcscheme
@@ -40,9 +40,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C28474CD1FFC0BFE00E13F56"
+               BuildableName = "Restivus-tvOSTests.xctest"
+               BlueprintName = "Restivus-tvOSTests"
+               ReferencedContainer = "container:Restivus.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -60,7 +70,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/http/ResultEncoding.swift
+++ b/Sources/http/ResultEncoding.swift
@@ -26,7 +26,9 @@ public enum ResultFormat {
                                      dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .deferredToDate) throws -> T {
         switch self {
         case .json:
-            return try JSONDecoder().decode(type, from: result)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = dateDecodingStrategy
+            return try decoder.decode(type, from: result)
         }
     }
     

--- a/Tests/ResultFormatSpec.swift
+++ b/Tests/ResultFormatSpec.swift
@@ -1,0 +1,50 @@
+//
+//  ResultFormatSpec.swift
+//  Restivus
+//
+//  Created by Ryan Baldwin on 2018-04-25.
+//Copyright © 2018 bunnyhug.me. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import Restivus
+
+class ResultFormatSpec: QuickSpec {
+    override func spec() {
+        describe("A JSON ResultFormat") {
+            it("defaults to using deferredToDate for all JSON Date Decoding") {
+                let currentDate = Date()
+                
+                do {
+                    let data = try JSONEncoder().encode(["date": currentDate])
+                    
+                    let deserializedData = try ResultFormat.json.decode(result: data, as: [String: Date].self)
+                    expect(deserializedData["date"]) == currentDate
+                } catch let error {
+                    fail("\(error)")
+                }
+            }
+            
+            it("uses the provided DateDecodingStrategy") {
+                let currentDate = Date()
+                
+                do {
+                    let encoder = JSONEncoder()
+                    encoder.dateEncodingStrategy = .millisecondsSince1970
+                    let data = try encoder.encode(["date": currentDate])
+                    
+                    let deserializedData = try ResultFormat.json.decode(result: data, as: [String: Date].self,
+                                                                        dateDecodingStrategy: .millisecondsSince1970)
+                    let currentComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second],
+                                                                            from: currentDate)
+                    let actualComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second],
+                                                                           from: deserializedData["date"]!)
+                    expect(currentComponents) == actualComponents
+                } catch let error {
+                    fail("\(error)")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Despite the interfaces supposedly advertising support for DateDecodingStrategy support, it wasn't actually ever used. The `ResultFormat.json.decode` function was only ever using the default DateDecodingStrategy on the JSONDecoder. This bug has existed since day 1 and never caught because, well, lets be frank, almost nobody uses this library, even though it's kinda rad.