### PR TITLE
Added a fix for `dateDecodingStrategy` not being used to decode

### DIFF
--- a/Restivus.xcodeproj/project.pbxproj
+++ b/Restivus.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		7DDB69561F4B6FA1001CC66D /* Restivous.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DDB69481F4B6FA1001CC66D /* Restivous.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7DDB69671F4B705D001CC66D /* Restable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DDB69631F4B705D001CC66D /* Restable.swift */; };
 		7DDB69751F4BE06B001CC66D /* HTTPURLResponse+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DDB69741F4BE06B001CC66D /* HTTPURLResponse+Extensions.swift */; };
+		9A64976520D2B5C200264C6E /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A64976420D2B5C200264C6E /* Date.swift */; };
 		C22D22D22090B0E500E78B03 /* ResultFormatSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22D22D12090B0E500E78B03 /* ResultFormatSpec.swift */; };
 		C22D22D32090B0E500E78B03 /* ResultFormatSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22D22D12090B0E500E78B03 /* ResultFormatSpec.swift */; };
 		C22D22D42090B0E500E78B03 /* ResultFormatSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22D22D12090B0E500E78B03 /* ResultFormatSpec.swift */; };
@@ -209,6 +210,7 @@
 		7DDB69551F4B6FA1001CC66D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7DDB69631F4B705D001CC66D /* Restable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Restable.swift; sourceTree = "<group>"; };
 		7DDB69741F4BE06B001CC66D /* HTTPURLResponse+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HTTPURLResponse+Extensions.swift"; sourceTree = "<group>"; };
+		9A64976420D2B5C200264C6E /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		C22D22D12090B0E500E78B03 /* ResultFormatSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultFormatSpec.swift; sourceTree = "<group>"; };
 		C2380A831F50B753004C1B04 /* DeletableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletableSpec.swift; sourceTree = "<group>"; };
 		C23F9A801F584395000CE9E6 /* RawDecodableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDecodableSpec.swift; sourceTree = "<group>"; };
@@ -331,6 +333,7 @@
 			children = (
 				7D72FA171F4E715000A4B3F9 /* Person.swift */,
 				7D424D4B1F4FC5C000D5C0B9 /* Restables.swift */,
+				9A64976420D2B5C200264C6E /* Date.swift */,
 			);
 			name = "Test Classes";
 			sourceTree = "<group>";
@@ -836,6 +839,7 @@
 				C28474ED1FFC11B800E13F56 /* RawDecodableSpec.swift in Sources */,
 				C28474DD1FFC11B800E13F56 /* PreEncodedRestableConfiguration.swift in Sources */,
 				C28474E01FFC11B800E13F56 /* HttpErrorSpec.swift in Sources */,
+				9A64976520D2B5C200264C6E /* Date.swift in Sources */,
 				C28474E81FFC11B800E13F56 /* AnyRestableSpec.swift in Sources */,
 				C28474E31FFC11B800E13F56 /* GettableSpec.swift in Sources */,
 				C28474EC1FFC11B800E13F56 /* OptionalResponseTypeSpec.swift in Sources */,

--- a/Sources/Restable.swift
+++ b/Sources/Restable.swift
@@ -309,7 +309,7 @@ extension Restable {
             }
             
             let jsonData = data ?? "{}".data(using: .utf8)!
-            let result = try resultFormat.decode(result: jsonData, as: ResponseType.self)
+            let result = try resultFormat.decode(result: jsonData, as: ResponseType.self, dateDecodingStrategy: dateDecodingStrategy)
             completion?(Result.success(result))
         } catch let error {
             print(error)

--- a/Tests/Date.swift
+++ b/Tests/Date.swift
@@ -1,0 +1,36 @@
+//
+//  Date.swift
+//  Restivus-iOSTests
+//
+//  Created by Adrian de Almeida on 2018-06-14.
+//  Copyright © 2018 bunnyhug.me. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import Restivus
+
+struct DateResponse: Decodable {
+    var date: Date
+}
+
+struct DateRequest: Gettable {
+    public typealias ResponseType = DateResponse
+    public var path: String { return "/test" }
+    public var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy {
+        return .formatted(dateFormatter())
+    }
+}
+
+extension DateRequest {
+    func dateFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+        return formatter
+    }
+}
+

--- a/Tests/Date.swift
+++ b/Tests/Date.swift
@@ -7,8 +7,6 @@
 //
 
 import Foundation
-import Quick
-import Nimble
 @testable import Restivus
 
 struct DateResponse: Decodable {

--- a/Tests/GettableSpec.swift
+++ b/Tests/GettableSpec.swift
@@ -36,33 +36,30 @@ class GettableSpec: QuickSpec {
                 let currentDateString = "2018-06-12T20:00:00.000-04:00"
                 let currentDate = gettable.dateFormatter().date(from: currentDateString)!
                 
-                expect {
-                    let data = """
-                    { "date": "\(currentDateString)" }
-                    """.data(using: .utf8)!
-                    
-                    var dateResponse: DateResponse? = nil
-                    
-                    // NOTE: We use a dummy url response here as the `dataTaskCompletionHandler` needs it.
-                    // As long as this method gets a success statusCode (ie. 200) from an HTTPURLResponse, it will proceed to decode the data passed in.
-                    // We want to verify that it is decoding it according to the `dateDecodingStrategy` of the `DateRequest`
-                    let response = HTTPURLResponse(url: URL(string: "http://google.ca")!, statusCode: 200, httpVersion: nil, headerFields: nil)
-                    gettable.dataTaskCompletionHandler(data: data, response: response, error: nil) { response in
-                        if case let .success(tempDateResponse) = response {
-                            dateResponse = tempDateResponse
-                        }
+                let data = """
+                { "date": "\(currentDateString)" }
+                """.data(using: .utf8)!
+                
+                var dateResponse: DateResponse? = nil
+                
+                // NOTE: We use a dummy url response here as the `dataTaskCompletionHandler` needs it.
+                // As long as this method gets a success statusCode (ie. 200) from an HTTPURLResponse, it will proceed to decode the data passed in.
+                // We want to verify that it is decoding it according to the `dateDecodingStrategy` of the `DateRequest`
+                let response = HTTPURLResponse(url: URL(string: "http://google.ca")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+                gettable.dataTaskCompletionHandler(data: data, response: response, error: nil) { response in
+                    if case let .success(tempDateResponse) = response {
+                        dateResponse = tempDateResponse
                     }
-                    
-                    expect(dateResponse).toNot(beNil())
-                    
-                    // compare the dates
-                    let currentComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: currentDate)
-                    let actualComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: dateResponse!.date)
-                    
-                    expect(currentComponents).toNot(beNil())
-                    expect(currentComponents) == actualComponents
-                    return nil
-                }.toNot(throwError())
+                }
+                
+                expect(dateResponse).toNot(beNil())
+                
+                // compare the dates
+                let currentComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: currentDate)
+                let actualComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: dateResponse!.date)
+                
+                expect(currentComponents).toNot(beNil())
+                expect(currentComponents) == actualComponents
             }
         }
     }

--- a/Tests/GettableSpec.swift
+++ b/Tests/GettableSpec.swift
@@ -16,6 +16,29 @@ extension Gettable {
     }
 }
 
+struct DateResponse: Decodable {
+    var date: Date
+}
+
+struct DateRequest: Gettable {
+    public typealias ResponseType = DateResponse
+    public var path: String { return "/test" }
+    public var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy {
+        return .formatted(dateFormatter())
+    }
+}
+
+extension DateRequest {
+    func dateFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+        return formatter
+    }
+}
+
 class GettableSpec: QuickSpec {
     override func spec() {
         describe("A default Gettable") {
@@ -28,6 +51,44 @@ class GettableSpec: QuickSpec {
             }
             
             itBehavesLike("a Restable") { context }
+        }
+        
+        describe("A gettable with a dateDecodingStrategy") {            
+            it("It decodes the response data according to the dateDecodingStrategy") {
+                let gettable = DateRequest()
+                let currentDateString = "2018-06-12T20:00:00.000-04:00"
+                let currentDate = gettable.dateFormatter().date(from: currentDateString)!
+                
+                do {
+                    // encode the date
+                    let encoder = JSONEncoder()
+                    encoder.dateEncodingStrategy = .formatted(gettable.dateFormatter())
+                    let data = try encoder.encode(["date": currentDateString])
+                    var dateResponse: DateResponse? = nil
+                    
+                    // NOTE: We use a dummy url response here as the `dataTaskCompletionHandler` needs it.
+                    // As long as this method gets a success statusCode (ie. 200) from an HTTPURLResponse, it will proceed to decode the data passed in.
+                    // We want to verify that it is decoding it according to the `dateDecodingStrategy` of the `DateRequest`
+                    let response = HTTPURLResponse(url: URL(string: "http://google.ca")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+                    gettable.dataTaskCompletionHandler(data: data, response: response, error: nil) { response in
+                        if case let .success(tempDateResponse) = response {
+                            dateResponse = tempDateResponse
+                        }
+                    }
+                    
+                    // compare the dates
+                    let currentComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: currentDate)
+                    var actualComponents: DateComponents? = nil
+                    if let dateResponse = dateResponse {
+                        actualComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: dateResponse.date)
+                    }
+                    
+                    expect(actualComponents).toNot(beNil())
+                    expect(currentComponents) == actualComponents
+                } catch let error {
+                    fail("\(error)")
+                }
+            }
         }
     }
 }

--- a/Tests/ResultFormatSpec.swift
+++ b/Tests/ResultFormatSpec.swift
@@ -45,6 +45,34 @@ class ResultFormatSpec: QuickSpec {
                     fail("\(error)")
                 }
             }
+            
+            it("uses the custom date formatters") {
+                let currentDateString = "2018-06-12T20:00:00.000-04:00"
+                
+                let formatter = DateFormatter()                
+                formatter.calendar = Calendar(identifier: .iso8601)
+                formatter.locale = Locale(identifier: "en_US_POSIX")
+                formatter.timeZone = TimeZone(secondsFromGMT: 0)
+                formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+                
+                let currentDate = formatter.date(from: currentDateString)!
+                
+                do {
+                    let encoder = JSONEncoder()
+                    encoder.dateEncodingStrategy = .formatted(formatter)
+                    let data = try encoder.encode(["date": currentDateString])
+                    
+                    let deserializedData = try ResultFormat.json.decode(result: data, as: [String: Date].self,
+                                                                        dateDecodingStrategy: .formatted(formatter))
+                    let currentComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second],
+                                                                            from: currentDate)
+                    let actualComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second],
+                                                                           from: deserializedData["date"]!)
+                    expect(currentComponents) == actualComponents
+                } catch let error {
+                    fail("\(error)")
+                }
+            }
         }
     }
 }

--- a/Tests/ResultFormatSpec.swift
+++ b/Tests/ResultFormatSpec.swift
@@ -44,35 +44,7 @@ class ResultFormatSpec: QuickSpec {
                 } catch let error {
                     fail("\(error)")
                 }
-            }
-            
-            it("uses the custom date formatters") {
-                let currentDateString = "2018-06-12T20:00:00.000-04:00"
-                
-                let formatter = DateFormatter()                
-                formatter.calendar = Calendar(identifier: .iso8601)
-                formatter.locale = Locale(identifier: "en_US_POSIX")
-                formatter.timeZone = TimeZone(secondsFromGMT: 0)
-                formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
-                
-                let currentDate = formatter.date(from: currentDateString)!
-                
-                do {
-                    let encoder = JSONEncoder()
-                    encoder.dateEncodingStrategy = .formatted(formatter)
-                    let data = try encoder.encode(["date": currentDateString])
-                    
-                    let deserializedData = try ResultFormat.json.decode(result: data, as: [String: Date].self,
-                                                                        dateDecodingStrategy: .formatted(formatter))
-                    let currentComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second],
-                                                                            from: currentDate)
-                    let actualComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second],
-                                                                           from: deserializedData["date"]!)
-                    expect(currentComponents) == actualComponents
-                } catch let error {
-                    fail("\(error)")
-                }
-            }
+            }            
         }
     }
 }


### PR DESCRIPTION
Hey admin dude, I've fixed the issue of `dateDecodingStrategy` not being used by `Restable` to decode data and created some tests. Take a look.